### PR TITLE
fix: bug with negative length

### DIFF
--- a/kcp2k/Assets/Tests/Editor/KcpTests.cs
+++ b/kcp2k/Assets/Tests/Editor/KcpTests.cs
@@ -304,13 +304,15 @@ namespace kcp2k.Tests
             // setup KCP
             Kcp kcp = new Kcp(0, Output);
 
-            // update once
-            uint time = 42;
-            kcp.Update(time);
+            // update at time = 1
+            kcp.Update(1);
 
-            // there is nothing to do, so check should return time + interval
-            uint next = kcp.Check();
-            Assert.That(next, Is.EqualTo(time + kcp.interval));
+            // check at time = 2
+            uint next = kcp.Check(2);
+
+            // check returns 'ts_flush + interval', or in other words,
+            // 'interval' seconds after UPDATE was called. so 1+100 = 101.
+            Assert.That(next, Is.EqualTo(1 + kcp.interval));
         }
     }
 }

--- a/kcp2k/Assets/kcp2k/VERSION
+++ b/kcp2k/Assets/kcp2k/VERSION
@@ -1,1 +1,6 @@
+V1.0
+- Kcp.cs now mirrors original Kcp.c behaviour
+  (this fixes dozens of bugs)
+
 V0.1
+- initial kcp-csharp based version

--- a/kcp2k/Assets/kcp2k/kcp/Kcp.cs
+++ b/kcp2k/Assets/kcp2k/kcp/Kcp.cs
@@ -512,7 +512,7 @@ namespace kcp2k
 
                 size -= OVERHEAD;
 
-                if (size < len || len < 0) return -2;
+                if (size < (int)len || (int)len < 0) return -2;
 
                 if (cmd != CMD_PUSH && cmd != CMD_ACK &&
                     cmd != CMD_WASK && cmd != CMD_WINS)

--- a/kcp2k/Assets/kcp2k/kcp/Kcp.cs
+++ b/kcp2k/Assets/kcp2k/kcp/Kcp.cs
@@ -911,7 +911,7 @@ namespace kcp2k
         // Important to reduce unnecessary update invoking. use it to schedule
         // update (eg. implementing an epoll-like mechanism, or optimize update
         // when handling massive kcp connections).
-        public uint Check()
+        public uint Check(uint current_)
         {
             uint ts_flush_ = ts_flush;
             int tm_flush = 0x7fffffff;
@@ -919,28 +919,28 @@ namespace kcp2k
 
             if (!updated)
             {
-                return current;
+                return current_;
             }
 
-            if (Utils.TimeDiff(current, ts_flush_) >= 10000 ||
-                Utils.TimeDiff(current, ts_flush_) < -10000)
+            if (Utils.TimeDiff(current_, ts_flush_) >= 10000 ||
+                Utils.TimeDiff(current_, ts_flush_) < -10000)
             {
-                ts_flush_ = current;
+                ts_flush_ = current_;
             }
 
-            if (Utils.TimeDiff(current, ts_flush_) >= 0)
+            if (Utils.TimeDiff(current_, ts_flush_) >= 0)
             {
-                return current;
+                return current_;
             }
 
-            tm_flush = Utils.TimeDiff(ts_flush_, current);
+            tm_flush = Utils.TimeDiff(ts_flush_, current_);
 
             foreach (Segment seg in snd_buf)
             {
-                int diff = Utils.TimeDiff(seg.resendts, current);
+                int diff = Utils.TimeDiff(seg.resendts, current_);
                 if (diff <= 0)
                 {
-                    return current;
+                    return current_;
                 }
                 if (diff < tm_packet) tm_packet = diff;
             }
@@ -948,7 +948,7 @@ namespace kcp2k
             uint minimal = (uint)(tm_packet < tm_flush ? tm_packet : tm_flush);
             if (minimal >= interval) minimal = interval;
 
-            return current + minimal;
+            return current_ + minimal;
         }
 
         // ikcp_setmtu

--- a/kcp2k/Assets/kcp2k/kcp/Kcp.cs
+++ b/kcp2k/Assets/kcp2k/kcp/Kcp.cs
@@ -256,6 +256,9 @@ namespace kcp2k
             if (len <= mss) count = 1;
             else count = (int)((len + mss - 1) / mss);
 
+            // this might be a kcp bug.
+            // it's possible that we should check 'count >= rcv_wnd' instead of
+            // the constant here.
             if (count >= WND_RCV) return -2;
 
             if (count == 0) count = 1;


### PR DESCRIPTION
len < 0 is always false,  because len is a uint and uint can never be negative.

The original C version casts to int here, so that the uint is converted to 2's compliment negative numbers.