### PR TITLE
Switch does not support ipv6

### DIFF
--- a/kcp2k/Assets/kcp2k/highlevel/KcpServer.cs
+++ b/kcp2k/Assets/kcp2k/highlevel/KcpServer.cs
@@ -40,6 +40,7 @@ namespace kcp2k
         // state
         Socket socket;
 #if UNITY_SWITCH
+// switch does not support ipv6
         EndPoint newClientEP = new IPEndPoint(IPAddress.Any, 0);
 #else
         EndPoint newClientEP = new IPEndPoint(IPAddress.IPv6Any, 0);

--- a/kcp2k/Assets/kcp2k/highlevel/KcpServer.cs
+++ b/kcp2k/Assets/kcp2k/highlevel/KcpServer.cs
@@ -40,7 +40,7 @@ namespace kcp2k
         // state
         Socket socket;
 #if UNITY_SWITCH
-// switch does not support ipv6
+            // switch does not support ipv6
         EndPoint newClientEP = new IPEndPoint(IPAddress.Any, 0);
 #else
         EndPoint newClientEP = new IPEndPoint(IPAddress.IPv6Any, 0);

--- a/kcp2k/Assets/kcp2k/highlevel/KcpServer.cs
+++ b/kcp2k/Assets/kcp2k/highlevel/KcpServer.cs
@@ -40,7 +40,7 @@ namespace kcp2k
         // state
         Socket socket;
 #if UNITY_SWITCH
-            // switch does not support ipv6
+        // switch does not support ipv6
         EndPoint newClientEP = new IPEndPoint(IPAddress.Any, 0);
 #else
         EndPoint newClientEP = new IPEndPoint(IPAddress.IPv6Any, 0);

--- a/kcp2k/Assets/kcp2k/highlevel/KcpServer.cs
+++ b/kcp2k/Assets/kcp2k/highlevel/KcpServer.cs
@@ -39,7 +39,11 @@ namespace kcp2k
 
         // state
         Socket socket;
+#if UNITY_SWITCH
+        EndPoint newClientEP = new IPEndPoint(IPAddress.Any, 0);
+#else
         EndPoint newClientEP = new IPEndPoint(IPAddress.IPv6Any, 0);
+#endif
         // IMPORTANT: raw receive buffer always needs to be of 'MTU' size, even
         //            if MaxMessageSize is larger. kcp always sends in MTU
         //            segments and having a buffer smaller than MTU would
@@ -82,13 +86,15 @@ namespace kcp2k
             }
 
             // listen
+#if UNITY_SWITCH
+            // Switch does not support ipv6
+            socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            socket.Bind(new IPEndPoint(IPAddress.Any, port));
+#else
             socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
-            // dual mode where available.
-            // (not available on nintendo switch, where it throws errors)
-#if !UNITY_SWITCH
             socket.DualMode = true;
-#endif
             socket.Bind(new IPEndPoint(IPAddress.IPv6Any, port));
+#endif
         }
 
         public void Send(int connectionId, ArraySegment<byte> segment, KcpChannel channel)


### PR DESCRIPTION
`socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);`

Switch does not support ipv6, so the following exception is thrown when using AddressFamily.InterNetworkV6

`SocketException: An address incompatible with the requested protocol was used
  at System.Net.Sockets.Socket..ctor (System.Net.Sockets.AddressFamily addressFamily, System.Net.Sockets.SocketType socketType, System.Net.Sockets.ProtocolType protocolType) [0x00000] in <00000000000000000000000000000000>:0 
  at kcp2k.KcpServer.Start (System.UInt16 port) [0x00000] in <00000000000000000000000000000000>:0 
  at kcp2k.KcpTransport.ServerStart () [0x00000] in <00000000000000000000000000000000>:0 
  at Mirror.NetworkServer.Listen (System.Int32 maxConns) [0x00000] in <00000000000000000000000000000000>:0 
  at Mirror.NetworkManager.SetupServer () [0x00000] in <00000000000000000000000000000000>:0 
  at Mirror.NetworkManager.StartHost () [0x00000] in <00000000000000000000000000000000>:0 
  at Mirror.Discovery.NetworkDiscoveryHUD.DrawGUI () [0x00000] in <00000000000000000000000000000000>:0 
  at Mirror.Discovery.NetworkDiscoveryHUD.OnGUI () [0x00000] in <00000000000000000000000000000000>:0 
 
(Filename: currently not available on il2cpp Line: -1)`