### PR TITLE
Add empty array segment for required out message

### DIFF
--- a/kcp2k/Assets/kcp2k/highlevel/KcpConnection.cs
+++ b/kcp2k/Assets/kcp2k/highlevel/KcpConnection.cs
@@ -241,6 +241,8 @@ namespace kcp2k
                 }
             }
 
+            // Create empty message result
+            message = new ArraySegment<byte>(kcpMessageBuffer, 0, 0);
             header = KcpHeader.Disconnect;
             return false;
         }

--- a/kcp2k/Assets/kcp2k/highlevel/KcpConnection.cs
+++ b/kcp2k/Assets/kcp2k/highlevel/KcpConnection.cs
@@ -241,8 +241,8 @@ namespace kcp2k
                 }
             }
 
-            // Create empty message result
-            message = new ArraySegment<byte>(kcpMessageBuffer, 0, 0);
+            // output empty message result
+            message = new ArraySegment<byte>(Array.Empty<byte>(), 0, 0);
             header = KcpHeader.Disconnect;
             return false;
         }


### PR DESCRIPTION
I want to test the library with .NET and noticed one compile error in KcpConnection in `bool ReceiveNextReliable(out KcpHeader header, out ArraySegment<byte> message)`. Since the message is set to out, it is required to be assigned. Setting it to an empty array segment seems like the proper way to do it.