### PR TITLE
Add support for multiple NICs and specifying which local IP to bind the server to.

### DIFF
--- a/kcp2k/Assets/kcp2k/MirrorTransport/KcpTransport.cs
+++ b/kcp2k/Assets/kcp2k/MirrorTransport/KcpTransport.cs
@@ -16,6 +16,7 @@ namespace kcp2k
         // common
         [Header("Transport Configuration")]
         public ushort Port = 7777;
+        public IPAddress LocalIP = IPAddress.IPv6Any;
         [Tooltip("NoDelay is recommended to reduce latency. This also scales better without buffers getting full.")]
         public bool NoDelay = true;
         [Tooltip("KCP internal update interval. 100ms is KCP default, but a lower interval is recommended to minimize latency and to scale to more networked entities.")]
@@ -148,7 +149,7 @@ namespace kcp2k
             return builder.Uri;
         }
         public override bool ServerActive() => server.IsActive();
-        public override void ServerStart() => server.Start(Port);
+        public override void ServerStart() => server.Start(Port, LocalIP);
         public override void ServerSend(int connectionId, int channelId, ArraySegment<byte> segment)
         {
             // switch to kcp channel.

--- a/kcp2k/Assets/kcp2k/highlevel/KcpServer.cs
+++ b/kcp2k/Assets/kcp2k/highlevel/KcpServer.cs
@@ -78,7 +78,7 @@ namespace kcp2k
 
         public bool IsActive() => socket != null;
 
-        public void Start(ushort port)
+        public void Start(ushort port, IPAddress address = null)
         {
             // only start once
             if (socket != null)
@@ -94,7 +94,7 @@ namespace kcp2k
 #else
             socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = true;
-            socket.Bind(new IPEndPoint(IPAddress.IPv6Any, port));
+            socket.Bind(new IPEndPoint(address ?? IPAddress.IPv6Any, port));
 #endif
         }
 


### PR DESCRIPTION
On servers with multiple NICs it may be necessary or desirable to bind a server to a specific one of them instead of listening on all available NICs.

I've added the ability to do this to the KCPTransport. Now you can do:

    KcpTransport.LocalIP = IPAddress.Parse("1.2.3.4");