### PR TITLE
Fixed nullref exception after stopping the KcpServer

### DIFF
--- a/kcp2k/Assets/kcp2k/highlevel/KcpServer.cs
+++ b/kcp2k/Assets/kcp2k/highlevel/KcpServer.cs
@@ -372,6 +372,7 @@ namespace kcp2k
 
         public virtual void Stop()
         {
+            connections.Clear();
             socket?.Close();
             socket = null;
         }


### PR DESCRIPTION
After calling KcpServer.Stop() method it destroys underlying socket, but don't clear the connections list. At the next Tick those connections tries to send a "Disconnect" message and throws exceptions because socket doesn't exist anymore.
Moreover, if you start the server again - those connections remain in the list and will spam errors trying to Disconnect themselves and failing due to wrong socket binding.

In short. We need to clear existing connections when stoppping the server.